### PR TITLE
fix right click menu bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dagbymurongqimiao",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5284,13 +5284,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5307,19 +5309,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5450,7 +5455,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5464,6 +5470,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5480,6 +5487,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5488,13 +5496,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5515,6 +5525,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5603,7 +5614,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5617,6 +5629,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5754,6 +5767,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/components/STEP/dagContent/editArea.vue
+++ b/src/components/STEP/dagContent/editArea.vue
@@ -37,10 +37,12 @@ export default {
       e.stopPropagation();
     },
     get_menu_style() {
+      let left = Number(this.isEditAreaShow.x) + Number(sessionStorage['svg_left']);
+      let top = Number(this.isEditAreaShow.y) + Number(sessionStorage['svg_top']);
       return {
         position: "absolute",
-        left: this.isEditAreaShow.x + 'px',
-        top: this.isEditAreaShow.y + 'px'
+        left: left + 'px',
+        top: top + 'px'
       }
     },
     delEdges() {
@@ -88,6 +90,6 @@ export default {
 }
 .menu_contain span:hover {
   background-color: rgba(40, 157, 233, 0.3);
-  cursor: none;
+  cursor: pointer;
 }
 </style>

--- a/src/components/STEP/dagContent/editArea.vue
+++ b/src/components/STEP/dagContent/editArea.vue
@@ -37,8 +37,8 @@ export default {
       e.stopPropagation();
     },
     get_menu_style() {
-      let left = Number(this.isEditAreaShow.x) + Number(sessionStorage['svg_left']);
-      let top = Number(this.isEditAreaShow.y) + Number(sessionStorage['svg_top']);
+      let left = this.isEditAreaShow.x;
+      let top = this.isEditAreaShow.y;
       return {
         position: "absolute",
         left: left + 'px',

--- a/src/components/STEP/dagContent/index.vue
+++ b/src/components/STEP/dagContent/index.vue
@@ -371,12 +371,8 @@ export default {
       // 节点右键模态
       this.setInitRect();
       const id = this.DataAll.nodes[i].id;
-      const x =
-        (e.x - this.initPos.left - (sessionStorage["svg_left"] || 0)) /
-        this.svgScale;
-      const y =
-        (e.y - this.initPos.top - (sessionStorage["svg_top"] || 0)) /
-        this.svgScale;
+      const x = e.x - this.initPos.left;
+      const y = e.y - this.initPos.top;
       this.is_edit_area = {
         value: true,
         x,

--- a/src/components/STEP/dagContent/index.vue
+++ b/src/components/STEP/dagContent/index.vue
@@ -39,9 +39,9 @@
           <SimulateFrame  v-if="currentEvent === 'PaneDraging'" :dragFrame="dragFrame" />
           <Arrow v-for="(each, n) in DataAll.edges" :key="'____' + n" :DataAll="DataAll" :each="each" :index="n" />
           <SimulateArrow v-if="currentEvent === 'dragLink'" :dragLink="dragLink"/>
-          <EditArea :isEditAreaShow="is_edit_area" @close_click_nodes="close_click_nodes"/>
           <SimulateSelArea v-if="['sel_area', 'sel_area_ing'].indexOf(currentEvent) !== -1" :simulate_sel_area="simulate_sel_area" />
       </g>
+      <EditArea :isEditAreaShow="is_edit_area" @close_click_nodes="close_click_nodes"/>
       <Control @sizeInit="sizeInit" @sizeExpend="sizeExpend" @sizeShrink="sizeShrink"  @sel_area="sel_area" :currentEvent="currentEvent" />
     </svg>
 </template>


### PR DESCRIPTION
1. 原版代码将EditArea模块放在画布拖动模块的子模块中会存在node拖动太远后，无法点击空白区域取消右键菜单的bug。解决方案：将EditArea模块移出该模块，根据session存储的画布拖动坐标与node自身坐标确定菜单位置。

2. 原版代码将菜单hover的cursor设为none，导致鼠标在菜单区域不显示。解决方案：修改cursor属性。